### PR TITLE
Add support for building CPU darknet_ros image too.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ ARG BASE_IMAGE_TAG=kinetic
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 
-ARG BASE_IMAGE=ros
-ARG BASE_IMAGE_TAG=kinetic
-
 # ---------------------------------------------
 
 RUN echo "source /opt/ros/kinetic/setup.sh" >> ~/.bashrc

--- a/Dockerfile.gpu-base
+++ b/Dockerfile.gpu-base
@@ -1,0 +1,14 @@
+FROM nvidia/cuda:9.0-devel
+
+ARG NVIDIA_COMPUTE=compute_52
+ENV NVIDIA_COMPUTE=${NVIDIA_COMPUTE}
+
+# Source the CUDA requirements
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda-9.0/lib64
+ENV PATH=${PATH}:/usr/local/cuda-9.0/bin
+
+# Install ROS Kinetic
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list' \
+    && apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116 \
+
+RUN rosdep init && rosdep update

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 * Docker
-* [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) and all [prerequisites](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)#prerequisites)
+* [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) and all [prerequisites](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)#prerequisites) if you are running with the GPU
 
 
 ## Running the dockerfile
@@ -11,10 +11,14 @@
 The included Dockerfile will create a container that runs a ROS interface for darknet/Yolo using the following commands:
 
     cd <darknet_ros home>
-	docker build -t darknet_ros .
-	docker run --runtime=nvidia -it --net=host darknet_ros:latest
-	
-Make sure you adjust the value of `NVIDIA_COMPUTE` in the Dockerfile.
+    # Build the CPU-only docker image
+    bash build_image.sh cpu
+
+    # Or build the GPU docker image (The final arg must be the compute number for your Nvidia card. See the build_image.sh usage for examples)
+    bash build_image.sh gpu compute_61
+
+    # Change the docker image tag to suit the image you want to run 
+	docker run --runtime=nvidia -it --net=host darknet_ros:<gpu|cpu>
 	
 By default the container will automatically start `roslaunch darknet_ros darknet_ros.launch`. This launches the classifier which listens on the topics specified in `darknet_ros/config/tut_yolo.yaml`. By default, the actionlib server listens on `/sut/check_for_objects`.
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Edge Case Research LLC. Copyright (C) 2018. All Rights Reserved
+
+set -ueo pipefail
+
+function printUsage() {
+    echo "Usage:  "
+    echo "  build_image.sh <target> [<nvidia_compute>]"
+    echo "  where <target> is one of:"
+    echo "      gpu      Build for Nvidia GPU with CUDA"
+    echo "      cpu      Build for CPU only"
+    echo "  where <nvidia_compute> is the compute number for your graphics card. It is required when the target is 'gpu'. Some examples are:"
+    echo "      compute_61      Alienware's GeForce GTX 1070 Ti"
+    echo "      compute_52      GeForce GTX 970M"
+    echo "      compute_37      AWS's Tesla K30"
+
+}
+
+
+TARGET="$1"
+NVIDIA_COMPUTE="${2:-}"
+
+if [ -z "$TARGET" ]; then
+    printUsage
+    exit 1
+fi
+
+IMAGE_NAME="darknet_ros"
+GPU_TAG="gpu"
+CPU_TAG="cpu"
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+
+
+if [ "${TARGET}" == "gpu" ]; then
+
+  if [ -z "$NVIDIA_COMPUTE" ]; then
+      printUsage
+      exit 1
+  fi
+    # Build the GPU base image
+
+
+    docker build \
+      --build-arg "NVIDIA_COMPUTE=${NVIDIA_COMPUTE}" \
+      -f "${THIS_DIR}/Dockerfile.gpu-base" \
+      -t "gpu-base:ros-kinetic-cuda-9.0" \
+      "${THIS_DIR}"
+
+    echo "------------------------------------------------------"
+
+    docker build \
+      --build-arg "BASE_IMAGE=gpu-base" \
+      --build-arg "BASE_IMAGE_TAG=ros-kinetic-cuda-9.0" \
+      -f "${THIS_DIR}/Dockerfile" \
+      -t "${IMAGE_NAME}:${GPU_TAG}" \
+      "${THIS_DIR}"
+
+fi
+
+if [ "${TARGET}" == "cpu" ]; then
+
+    docker build \
+      --build-arg "BASE_IMAGE=ros" \
+      --build-arg "BASE_IMAGE_TAG=kinetic" \
+      -f "${THIS_DIR}/Dockerfile" \
+      -t "${IMAGE_NAME}:${CPU_TAG}" \
+      "${THIS_DIR}"
+fi


### PR DESCRIPTION
I created a script to build the two docker images. There are two Dockerfiles now. for GPU we install ROS on the cuda base image before moving on to the main Dockerfile where we install darknet. For the CPU we just use the main Dockerfile with a base image of ros:kinetic