### PR TITLE
removed roslaunch from dockerfile. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ RUN echo "source $(pwd)/install/setup.sh" >> ~/.bashrc
 WORKDIR /workspace
 
 # Run the ros interface by default
-CMD /bin/bash -c "source /opt/ros/kinetic/setup.bash && source darknet_ros/install/setup.bash && roslaunch darknet_ros darknet_ros.launch"
+CMD /bin/bash -c "source /opt/ros/kinetic/setup.bash && source darknet_ros/install/setup.bash"
 


### PR DESCRIPTION
Having the SUT running at launch means that it cannot connect to the ROS master running on the TUT container